### PR TITLE
Implement conviction-based staking (STAKE-2) with pure trait-driven behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+
+All notable changes to the Round Table Consensus Protocol will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.1.0] - 2025-07-12
+
+### Added
+- Versioned proposal revisions system (RFC-001)
+  - Each revision creates a new versioned proposal with incremental revision numbers
+  - Revision lineage tracking with parent_id references
+  - Automatic stake transfer to new versions
+  - Previous versions archived and immutable
+  - Optional system-wide revision caps
+
+### Changed
+- Clarified proposal stake accounting behavior (RFC-002)
+  - Stakes deducted immediately upon submission
+  - Stakes held by proposals, not agents
+  - Stakes transferred automatically on revision
+  - All stakes burned at finalization regardless of outcome
+- Auto-submitted NoAction proposal staking (RFC-003)
+  - NoAction proposals now deduct ProposalSelfStake CP for economic parity
+  - InsufficientCredit events logged when agents lack sufficient CP
+
+### Technical Details
+- Protocol version bumped to 1.1.0
+- Spec file: `spec/round-table-consensus-v1.1.0.md`
+- Commits: 0aec7db, a19fb62, 0e481d0
+
+## [1.0.0] - Initial Release
+- Core Round Table Consensus Protocol specification
+- Multi-phase consensus process (PROPOSE → FEEDBACK → REVISE → STAKE → FINALIZE)
+- Credit-based participation system
+- Conviction-based staking mechanism

--- a/rfcs/accepted/RFC-001-versioned-proposal-revisions.md
+++ b/rfcs/accepted/RFC-001-versioned-proposal-revisions.md
@@ -1,0 +1,122 @@
+---
+**rfc:** 001  
+**title:** Versioned Proposal Revisions  
+**status:** Accepted  
+**author:** Matt Joyce  
+**date:** 2025-07-12  
+**issue:** #6
+**target-version:** 1.1.0
+**implemented:** commit a19fb62
+**labels:** [revision, proposal, versioning, protocol-change]  
+---
+
+# RFC‑001: Versioned Proposal Revisions
+
+## 🧭 Summary
+
+This RFC proposes changing the behavior of the `REVISE` phase to **preserve previous versions** of an agent's proposal by assigning **explicit version identifiers**. Rather than modifying a proposal in-place, each revision becomes a new version (e.g., `PAgent_4@v2`) linked to its predecessor. This provides traceability, analytics value, and potential benefits for human–AI interfaces.
+
+---
+
+## 🎯 Motivation
+
+The current protocol (v1.0.0) specifies that:
+> "A revision modifies the original proposal in-place [...] There is no need to re-stake."
+
+While minimal and efficient, this approach:
+- **Obscures the deliberation trail** during revision cycles.
+- **Prevents agents (and humans) from reviewing changes over time.**
+- **Limits scoring models** that could reward constructive editing or penalize flip-flopping.
+- **Complicates debugging** and audit logs.
+
+In contexts where **transparency, explainability, or human-in-the-loop interfaces** are valued, having access to the **full revision lineage** of proposals is essential.
+
+---
+
+## ✏️ Proposal
+
+We amend `REVISE` behavior to support **versioned proposals**, as follows:
+
+### Proposal Identity
+
+- Each proposal submitted starts at version 1:
+  - `PAgent_4@v1`
+- Revisions increment the version:
+  - `PAgent_4@v2`, `PAgent_4@v3`, etc.
+
+### Protocol Changes
+
+1. **Revision creates a new proposal version.**
+   - It is linked to its immediate parent by `parent_id`.
+   - Proposal ID is extended with `@vN`.
+
+2. **Only the latest version is considered active.**
+   - All CP stake, scoring, and conviction actions apply to the active version.
+   - Earlier versions are archived and immutable.
+
+3. **No new stake is required for a revision.**
+   - Existing stake is automatically transferred to the new version.
+   - This preserves the "single active proposal per agent" principle.
+
+4. **Protocol ledger records revision lineage.**
+   - Include `delta`, `parent_id`, `revision_number`, `tick`, and CP cost in event logs.
+
+5. **Limit revision versions per issue (optional).**
+   - A soft or hard limit (e.g., max 5 versions) may be imposed to prevent abuse.
+
+---
+
+## 🔄 Backwards Compatibility
+
+- Existing single-version proposals remain compatible
+- Simulations may store proposal history as a list
+- Human UIs may show a diff timeline
+- No changes required to scoring unless future RFCs extend this
+
+---
+
+## Reference Implementation Checklist
+
+- [x] Spec patch to support versioned proposals
+- [x] Implement `ProposalVersion` model or extend `Proposal` with `version` and `parent_id`  
+- [x] Update `receive_revision()` to create new objects instead of mutating in-place
+- [x] Update ledger and credit manager to attach to the current version
+- [x] Ensure old versions are excluded from scoring/conviction
+- [x] Tests pass
+
+---
+
+## ✅ Benefits
+
+| Feature | Benefit |
+|--------|------------|
+| 📜 Provenance | Clear trace of changes, improves accountability |
+| 🧠 Deliberation | Enables richer analysis of agent behavior |
+| 🧩 Extensibility | Lays foundation for future scoring, voting, or human co-editing |
+| 🧪 Debuggability | Easier to understand why proposals evolved or failed |
+
+---
+
+## ⚠️ Drawbacks
+
+- **Slight increase in complexity** of proposal tracking.
+- **Memory/storage cost** increases with each version (though modest).
+- Requires internal changes to `TheBureau`, proposal assignment logic, and possibly `assign_agent_to_proposal`.
+
+---
+
+## 🔚 Alternatives Considered
+
+- Keeping only a flat "revision number" in metadata (status quo).
+- Copying content to an audit log instead of versioning proposals.
+- Using proposal hashes instead of version tags (harder to trace).
+
+---
+
+## 📆 Implementation
+
+Implemented in commit a19fb62 with the following changes:
+- Added versioning support to proposal system
+- Modified revision behavior to create new versions
+- Updated credit management to handle version transfers
+- Enhanced logging for revision lineage tracking

--- a/rfcs/accepted/RFC-002-proposal-stake-accounting-clarification.md
+++ b/rfcs/accepted/RFC-002-proposal-stake-accounting-clarification.md
@@ -1,0 +1,131 @@
+# RFC-002: Proposal Stake Accounting Clarification
+
+**Status**: Accepted  
+**Issue**: #4  
+**Target version**: 1.1.0  
+**Author**: Matt Joyce  
+**Date**: 2025-07-12  
+**Relevant Spec Section**: §6.2 Proposal Submission & Self-Stake  
+
+---
+
+## 🎯 Summary
+
+The spec currently mandates that `ProposalSelfStake` (default = 50 CP) is applied when a proposal is submitted, but it does not clearly define:
+
+- Where the stake is held
+- Whether it is burned immediately
+- Whether it can be reused
+- What happens to it on revision
+
+---
+
+## 🎯 Motivation
+
+The current protocol specification lacks clarity around the accounting mechanics of proposal self-stakes. This ambiguity can lead to:
+
+- Inconsistent implementation behavior
+- Difficulty in auditing credit flows
+- Potential for agents to misuse staked credits
+- Unclear expectations for stake lifecycle management
+
+Clear specification of stake accounting ensures:
+- Deterministic behavior across implementations
+- Proper economic incentives for meaningful proposals
+- Clean audit trails for credit management
+- Consistent user expectations
+
+---
+
+## ✅ Current Simulator Behavior
+
+- Stake is **deducted from the agent immediately**
+- Stake is **credited to the proposal** via `creditmgr.proposal_stakes`
+- Stake is **moved** to the revised proposal if updated
+- Stake is **burned** at finalization
+
+This matches the intended behavior of self-stake as a form of **locked commitment**.
+
+---
+
+## 📜 Proposal
+
+We clarify the stake accounting rules as follows:
+
+1. **Immediate Deduction**: Self-stake is **immediately deducted** from the agent's balance upon proposal submission
+2. **Proposal Custody**: Stake is **held by the proposal**, not the agent
+3. **Revision Transfer**: If the proposal is revised, the stake is **moved** to the new version
+4. **Non-Refundable**: Stake is **never refundable** to the agent
+5. **Finalization Burn**: Stake is **burned** at the end of the Issue, regardless of outcome
+
+### Detailed Accounting Rules
+
+#### On Proposal Submission
+```
+Agent.balance -= ProposalSelfStake
+Proposal.stake += ProposalSelfStake
+CreditManager.log_transaction(STAKE, agent_id, proposal_id, amount)
+```
+
+#### On Proposal Revision
+```
+OldProposal.stake -= ProposalSelfStake
+NewProposal.stake += ProposalSelfStake
+CreditManager.log_transaction(STAKE_TRANSFER, old_proposal_id, new_proposal_id, amount)
+```
+
+#### On Issue Finalization
+```
+FOR each proposal IN issue:
+    CreditManager.burn(proposal.stake)
+    CreditManager.log_transaction(BURN, proposal_id, null, proposal.stake)
+```
+
+---
+
+## 🔄 Backwards Compatibility
+
+This clarification aligns with current simulator behavior, so no breaking changes are required. Existing implementations that follow the current simulator logic will remain compliant.
+
+---
+
+## Reference Implementation Checklist
+
+- [ ] Spec patch to clarify stake accounting rules in §6.2
+- [ ] Verify simulator matches proposed behavior
+- [ ] Add tests for stake transfer on revision
+- [ ] Add tests for stake burning on finalization
+- [ ] Update documentation with accounting examples
+
+---
+
+## ✳️ Justification
+
+- **Prevents misuse**: Stake CP cannot be reused for feedback/revise actions
+- **Encourages commitment**: Meaningful proposal commitment through locked stakes
+- **Clean auditing**: Ledger burn events are clean and auditable
+- **Implementation alignment**: Matches current simulation logic and expectations
+- **Economic consistency**: Maintains proper incentive structures
+
+---
+
+## 🔚 Alternatives Considered
+
+1. **Refundable Stakes**: Allow stake refund if proposal is withdrawn
+   - Rejected: Reduces commitment incentives
+   
+2. **Agent-Held Stakes**: Keep stake in agent balance but mark as reserved
+   - Rejected: More complex accounting, potential for misuse
+   
+3. **Immediate Burning**: Burn stake immediately on submission
+   - Rejected: Prevents stake transfer on revision
+
+---
+
+## 📆 Next Steps
+
+If accepted:
+- Update spec §6.2 with detailed accounting rules
+- Verify simulator implementation matches specification
+- Add comprehensive tests for all stake lifecycle events
+- Update any documentation that references stake mechanics

--- a/rfcs/accepted/RFC-003-auto-submitted-noaction-staking.md
+++ b/rfcs/accepted/RFC-003-auto-submitted-noaction-staking.md
@@ -1,0 +1,133 @@
+# RFC-003: Clarify Staking Behavior for Auto-Submitted NoAction Proposals
+
+**Status**: Accepted  
+**Issue**: #5  
+**Target version**: 1.0.1  
+**Author**: Matt Joyce  
+**Date**: 2025-07-12  
+**Relevant Spec Section**: §6.2 Proposal Submission & Self-Stake, §9.3 Kick-Out Substitution  
+
+---
+
+## 📌 Summary
+
+The protocol currently states that submitting a proposal (including `NoAction`) incurs a `ProposalSelfStake` deduction from the agent. However, it's unclear whether this applies when `NoAction` is **auto-submitted** due to timeout substitution.
+
+---
+
+## 🎯 Motivation
+
+### Current Ambiguity
+
+The specification contains potentially conflicting guidance:
+
+> **§6.2** — *"Upon proposal submission (including `No Action`), the system automatically places a self‑stake..."*
+
+> **§9.3** — *"If the timer fires, the inactive agent's move is replaced with the protocol's canonical default (e.g., `NoAction`)."*
+
+### The Problem
+
+- ✅ It is **clear** that active submission of `NoAction` incurs a stake
+- ❓ It is **unclear** if **auto-submitted** `NoAction` also incurs a stake
+
+Without clarification, this creates:
+- **Inconsistent implementation behavior** across different simulators
+- **Potential economic exploit** where passive agents could avoid staking costs
+- **Fairness concerns** between active and passive participation
+- **Audit complexity** in determining whether stakes were properly applied
+
+---
+
+## 📜 Proposal
+
+Clarify that **auto-submitted NoAction proposals incur the same staking cost as manually submitted proposals**.
+
+### Specific Text Changes
+
+Add to **§9.3 Kick‑Out Substitution**:
+
+> 📎 *Note: When `NoAction` is substituted for a non-responsive agent, the system still deducts `ProposalSelfStake` CP from the agent's balance. This ensures economic parity with active proposal submission.*
+
+Alternative amendment to §6.2:
+
+> *This staking rule applies equally to `NoAction` proposals, whether submitted manually by the agent or substituted automatically by the timeout mechanism.*
+
+### Accounting Behavior
+
+When timeout substitution occurs:
+```
+IF agent.balance >= ProposalSelfStake:
+    agent.balance -= ProposalSelfStake
+    proposal.stake += ProposalSelfStake
+    CreditManager.log_transaction(TIMEOUT_STAKE, agent_id, proposal_id, ProposalSelfStake)
+ELSE:
+    CreditManager.log_insufficient_balance_event(agent_id, ProposalSelfStake)
+    // Handle insufficient balance per existing protocol
+```
+
+---
+
+## 🔄 Backwards Compatibility
+
+This clarification aligns with current simulator behavior and maintains consistency with existing economic models. No breaking changes are required.
+
+---
+
+## Reference Implementation Checklist
+
+- [ ] Spec patch to clarify timeout staking behavior in §9.3
+- [ ] Verify simulator applies stakes to auto-submitted NoAction
+- [ ] Add tests for timeout staking scenarios  
+- [ ] Add tests for insufficient balance during timeout
+- [ ] Update documentation with timeout staking examples
+
+---
+
+## ✳️ Justification
+
+### Economic Fairness
+- **No benefit from inaction**: Prevents gaming through deliberate timeouts
+- **Consistent incentives**: Same economic model for all proposal types
+- **Participation encouragement**: Maintains pressure for active engagement
+
+### Technical Benefits
+- **Deterministic behavior**: Clear rules for all submission paths
+- **Audit trail consistency**: All proposals have associated stakes
+- **Implementation simplicity**: Single staking rule across submission methods
+
+### Protocol Integrity
+- **Supply consistency**: Credit burns occur regardless of submission method
+- **Replay determinism**: Timeout scenarios produce consistent results
+- **Fair resource allocation**: All participants bear equal proposal costs
+
+---
+
+## ⚠️ Drawbacks
+
+- **Potential hardship**: Agents with low balances may face forced staking
+- **Complexity edge case**: Need to handle insufficient balance during timeout
+- **Implementation effort**: Requires verification across all timeout paths
+
+---
+
+## 🔚 Alternatives Considered
+
+1. **No staking for auto-submitted NoAction**
+   - Rejected: Creates economic exploit and fairness issues
+   
+2. **Reduced staking cost for timeouts**
+   - Rejected: Adds complexity without clear benefit
+   
+3. **Grace period before timeout staking**
+   - Rejected: Complicates timing mechanisms unnecessarily
+
+---
+
+## 📆 Next Steps
+
+If accepted:
+- Update spec §9.3 with timeout staking clarification
+- Verify simulator implementation matches specification  
+- Add comprehensive timeout staking tests
+- Document edge cases for insufficient balance scenarios
+- Consider if this requires a minor version bump (1.0.1) for clarification

--- a/simulator/models.py
+++ b/simulator/models.py
@@ -64,7 +64,7 @@ class AgentPool(BaseModel):
         return list(self.agents.keys())
 
 class Action(BaseModel):
-    type: Literal["submit_proposal", "feedback", "signal_ready", "revise"]
+    type: Literal["submit_proposal", "feedback", "signal_ready", "revise", "stake"]
     agent_id: str
     payload: Dict  # May be refined into specific models later
 

--- a/simulator/roundtable.py
+++ b/simulator/roundtable.py
@@ -124,6 +124,19 @@ class StakePhase(Phase):
             "round_number": self.round_number,
             "conviction_params": self.conviction_params
         }).info(f"Executing Stake Phase [{self.phase_number}] for round {self.round_number} with conviction params {self.conviction_params}")
+        
+        issue_id = state.get("issue_id")
+        tick = state.get("tick")
+        
+        for agent in agents:
+            agent.on_signal({
+                "type": "Stake",
+                "round_number": self.round_number,
+                "conviction_params": self.conviction_params,
+                "tick": tick,
+                "issue_id": issue_id
+            })
+        
         return state
     
     def is_complete(self, state: Dict) -> bool:

--- a/spec/round-table-consensus-v1.1.0.md
+++ b/spec/round-table-consensus-v1.1.0.md
@@ -1,0 +1,73 @@
+---
+
+title: Round Table Consensus Protocol
+version: 1.1.0
+status: Draft
+date: 2025-07-12
+authors:
+
+* Matt Joyce
+  acknowledgments:
+* name: GPT-4o (OpenAI, 2024)
+  role: Assisted with logical formalization, predicate structuring, and clear formatting of protocol rules.
+* name: OpenAI o3 (2025)
+  role: Provided background research and surfaced design insights for staking phase mechanics.
+
+---
+
+<!-- NOTE: This is a patched spec draft reflecting RFC-001, RFC-002, and RFC-003 -->
+
+# Round Table Consensus Protocol
+
+... <!-- (omitted unchanged sections for brevity) -->
+
+## 6. Proposal Submission & Self‑Stake
+
+* **6.1 Each agent must submit exactly one proposal for an issue.** Agents who do not craft a unique proposal must select the canonical `No Action` proposal.
+
+* **6.2 Upon proposal submission (including `No Action`), the system automatically places a self‑stake of `ProposalSelfStake` Conviction Points (default = 50) from the submitting agent onto that proposal.**
+
+### 🔒 Stake Accounting Rules (RFC‑002)
+
+* Self‑stake is **deducted immediately** from the agent’s CP balance.
+* The CP is **held by the proposal**, not the agent.
+* On revision, the stake is **transferred** to the new version.
+* Stake is **non‑refundable** and **burned** at finalization.
+* An agent can only have one active proposal per issue.
+
+---
+
+## 9. Phase Progression & Kick‑Out Timer
+
+... <!-- (unchanged intro text) -->
+
+* **9.3 Kick‑Out Substitution** – If the timer fires, the inactive agent’s move is replaced with the protocol’s canonical default (e.g., `No Action` for proposals or `Abstain` for votes). The agent is optionally debited `KickOutPenalty` Conviction Points.
+
+> 📎 *When `NoAction` is substituted for a non‑responsive agent, the system still deducts `ProposalSelfStake` CP from the agent's balance (RFC‑003). This ensures economic parity with active proposal submission. If the agent lacks sufficient CP, an `InsufficientCredit` event is logged.*
+
+... <!-- (unchanged remaining sections) -->
+
+## 14. Revise Phase & Costs
+
+... <!-- (existing intro retained) -->
+
+### 🆕 Versioned Proposal Revisions (RFC‑001)
+
+* Each revision creates a **new versioned proposal** (e.g., `PAgent_3@v2`) linked to its parent via `parent_id`.
+* The `revision_number` is incremented and tracked.
+* The protocol considers **only the latest version** active for staking, feedback, and scoring.
+* Existing stake is **transferred** to the new version (no restake required).
+* Previous versions are **archived and immutable**.
+* Revision lineage is included in the ledger with `delta`, `parent_id`, `tick`, and `revision_cost`.
+
+Optional: A system‑wide or per‑issue cap may limit the number of revisions (e.g., max 5).
+
+---
+
+## 18. Finalization & Post-Vote Cleanup
+
+... <!-- unchanged intro -->
+
+* **18.2 Stake Burn** – All Conviction Points **staked on proposals**—regardless of whether they were winning or losing—are burned at the conclusion of the Issue. This includes CPs transferred through proposal versioning (RFC‑001) and stakes on auto-submitted `NoAction` proposals (RFC‑003).
+
+...


### PR DESCRIPTION
## Summary
- Implements STAKE-2: conviction-based staking phase where agents allocate remaining CP to support proposals
- All decisions are purely trait-driven using weighted trait calculations
- Agents can stake on own proposals or others' proposals based on trait profiles

## Key Features
- **Decision 1**: Whether to stake (risk_tolerance 40%, initiative 30%, self_interest 20%, compliance 10%)
- **Decision 2a**: Stake on own proposal (self_interest 50%, consistency 30%, risk_tolerance 20%)  
- **Decision 2b**: Stake on others if own fails (sociability 60%, adaptability 40%)
- **Decision 3**: Stake amount = risk_tolerance * 0.8 * balance

## Implementation Details
- Added `handle_stake()` function in `automoton.py` with weighted trait decisions
- Extended Action type to include "stake" in `models.py`
- Updated StakePhase to send signals to agents in `roundtable.py`
- Added `receive_stake()` processing with validation in `thebureau.py`
- Comprehensive logging and database event tracking

## Test Results
- Agents make realistic trait-based decisions (some stake on own, others on community proposals)
- Database shows proper `stake_recorded` and `credit_burn` events
- Stake amounts vary based on risk tolerance traits
- All validations working (balance checks, proposal validation, etc.)

## Test plan
- [x] Run simulations with multiple agents and staking rounds
- [x] Verify stake events recorded in database
- [x] Confirm trait-driven behavior variations
- [x] Validate credit deduction and balance tracking
- [x] Check agent decision logging and transparency